### PR TITLE
Introducing phisolve backend

### DIFF
--- a/examples/4_test_phisolve.ipynb
+++ b/examples/4_test_phisolve.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8a629179",
+   "metadata": {},
+   "source": [
+    "## QHDOPT for quadratic programming\n",
+    "\n",
+    "In this notebook, we demonstrate how to employ QHDOPT to solve a quadratic programming problem with box constraints. \n",
+    "\n",
+    "Our target problem is $$\\min \\ f(x)=\\frac{1}{2}x^TQx+b^Tx,$$ where $Q = \\begin{bmatrix}-2 & 1 \\\\ 1 & -1 \\end{bmatrix}, b = \\begin{bmatrix}\\frac{3}{4} \\\\ -\\frac{1}{4}\\end{bmatrix},$ and $x$ is a 2-dimensional variable vector with each entry constrained in $[0, 1]$.\n",
+    "\n",
+    "We employ the QP mode of QHDOPT to input this problem."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58309b05",
+   "metadata": {},
+   "source": [
+    "### 1. Create problem instance\n",
+    "\n",
+    "First, we import the class QHD from our package QHDOPT, implying the solver's algorithm. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bda849f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qhdopt import QHD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a64c0be",
+   "metadata": {},
+   "source": [
+    "Next, we construct the matrices $Q$ and $b$ by Python lists. For the matrix $Q$, it is represented by a nested list. The vector $b$ is represented by a list, encoding its transposed matrix $b^T$. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fccf79e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Q = [[-2, 1],\n",
+    "     [1, -1]]\n",
+    "bt = [3/4, -1/4]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c6906ab",
+   "metadata": {},
+   "source": [
+    "Then we create a problem instance, stored in a variable `model`. It mandates the matrices $Q$ and $b$ to construct the problem, and by default set the box constraints to the unit box $[0, 1]^n$. You may override the bounds by `bounds=(l, r)` or `bounds=[(l1, r1), ..., (ln, rn)]`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6b366a7e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "* Runtime breakdown\n",
+      "SimuQ compilation: 0.000 s\n",
+      "Backend runtime: 0.088 s\n",
+      "Decoding time: 0.000 s\n",
+      "Classical (Fine-tuning) time: 0.035 s\n",
+      "* Total time: 0.123 s\n",
+      "\n",
+      "* Coarse solution\n",
+      "Minimizer: [0. 1.]\n",
+      "Minimum: -0.75\n",
+      "\n",
+      "* Fine-tuned solution\n",
+      "Minimizer: [0. 1.]\n",
+      "Minimum: -0.75\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<qhdopt.response.Response at 0x33a6994c0>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = QHD.QP(Q, bt)\n",
+    "\n",
+    "# test PhiSolve Backend\n",
+    "model.phisolve_setup(resolution=6)\n",
+    "model.optimize(verbose=1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "QHDOPT",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/qhdopt/backend/phisolve_backend.py
+++ b/qhdopt/backend/phisolve_backend.py
@@ -1,0 +1,191 @@
+import time
+import random
+from typing import Tuple, List
+
+from qhdopt.backend.backend import Backend
+from simuq import QSystem, Qubit
+from simuq.dwave import DWaveProvider
+import qutip as qtp
+import numpy as np
+
+from qhdopt.utils.decoding_utils import binstr_to_bitstr
+
+from dimod import ising_to_qubo
+from phisolve import PhiMIQP, QIHD, MIQP
+
+
+
+class PhiSolveBackend(Backend):
+    """
+    Backend implementation for PhiSolve.
+    """
+    def __init__(self,
+                 resolution,
+                 dimension,
+                 univariate_dict,
+                 bivariate_dict,
+                 shots=100,
+                 n_steps=10000,
+                 ballistic=False,
+                 device='cpu',
+                 seed=None,
+                 dt=0.2,
+                 a0=1.0,
+                 symplectic_integration=False,
+                 slow_a=True,
+                 embedding_scheme="unary",
+                 penalty_coefficient=0,
+                 penalty_ratio=0.75,
+                 chain_strength_ratio=0):
+        super().__init__(resolution, dimension, shots, embedding_scheme, univariate_dict, bivariate_dict)
+        self.n_steps = n_steps
+        self.ballistic = ballistic
+        self.device = device 
+        self.seed = seed 
+        self.dt = dt 
+        self.a0 = a0 
+        self.symplectic_integration = symplectic_integration 
+        self.slow_a = slow_a
+        self.penalty_coefficient = penalty_coefficient
+        self.penalty_ratio = penalty_ratio
+        self.chain_strength_ratio = chain_strength_ratio
+
+
+    def calc_penalty_coefficient_and_chain_strength(self) -> Tuple[float, float]:
+        """
+        Calculates the penalty coefficient and chain strength using self.penalty_ratio.
+        """
+        if self.penalty_coefficient != 0:
+            chain_strength = np.max([5e-2, self.chain_strength_ratio * self.penalty_coefficient])
+            return self.penalty_coefficient, chain_strength
+          
+        qs = QSystem()
+        qubits = [Qubit(qs) for _ in range(len(self.qubits))]
+        qs.add_evolution(self.S_x(qubits) + self.H_p(qubits, self.univariate_dict, self.bivariate_dict), 1)
+        dwp = DWaveProvider(api_key='')
+        h, J = dwp.compile(qs, chain_strength=.0)
+        max_strength = np.max(np.abs(list(h) + list(J.values())))
+        penalty_coefficient = (
+            self.penalty_ratio * max_strength if self.embedding_scheme == "unary" else 0
+        )
+        # chain_strength = np.max([5e-2, 0.5 * self.penalty_ratio])
+        # chain_strength_multiplier = np.max([1, self.penalty_ratio])
+        # chain_strength = np.max([5e-2, chain_strength_multiplier * max_strength])
+        chain_strength = .0
+        return penalty_coefficient, chain_strength
+
+    def compile(self, info, override=None):
+        penalty_coefficient, chain_strength = self.calc_penalty_coefficient_and_chain_strength()
+
+        if override is not None:
+            # penalty_coefficient, chain_strength = 3.5e-2, 4e-2
+            penalty_coefficient, chain_strength = override
+
+        self.penalty_coefficient, self.chain_strength = penalty_coefficient, chain_strength
+        self.qs.add_evolution(
+            self.H_p(self.qubits, self.univariate_dict, self.bivariate_dict) + penalty_coefficient * self.H_pen(self.qubits), 1
+        )
+
+        self.dwp = DWaveProvider(api_key='')
+        start_compile_time = time.time()
+        h, J = self.dwp.compile(self.qs, chain_strength=.0)
+        n_vars = len(h)
+        h = {i: h[i] for i in range(n_vars)}
+        qubo_dict, _ = ising_to_qubo(h, J)
+        Q = np.zeros((n_vars, n_vars))
+        for (i, j), v in qubo_dict.items():
+            Q[i, j] = v
+            Q[j, i] = v
+        # self.qihd_backend = QIHD(Q=Q, n_binary_vars=n_vars)
+        qihd_backend = QIHD(n_shots=self.shots,
+                            n_steps=self.n_steps,
+                            ballistic=self.ballistic,
+                            device=self.device,
+                            seed=self.seed,
+                            dt=self.dt,
+                            a0=self.a0,
+                            symplectic_integration=self.symplectic_integration,
+                            slow_a=self.slow_a
+            )
+        self.phiqubo_model = PhiMIQP(
+            MIQP(Q=Q, w=np.zeros(n_vars), n_binary_vars=n_vars), 
+            backend=qihd_backend,
+            )
+        end_compile_time = time.time()
+        info["compile_time"] = end_compile_time - start_compile_time
+
+    def exec(self, verbose: int, info: dict, compile_only=False, override=None) -> List[List[int]]:
+        """
+        Execute the Dwave quantum backend using the problem description specified in
+        self.univariate_dict and self.bivariate_dict. It uses self.H_p to generate
+        the problem hamiltonian and then uses Simuq's DwaveProvider to run the evolution
+        on Dwave.
+
+        Args:
+            verbose: Verbosity level.
+            info: Dictionary to store information about the execution.
+            compile_only: If True, the function only compiles the problem and does not run it.
+
+        Returns:
+            raw_samples: A list of raw samples from the Dwave backend.
+        """
+        self.compile(info, override)
+
+        if verbose > 1:
+            self.print_compilation_info()
+
+        if verbose > 1:
+            print("Initiating PhiSolve:")
+            print(time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime()))
+
+        start_run_time = time.time()
+        # self.dwave_response = self.dwp.run(shots=self.shots)
+        self.phisolve_response = self.phiqubo_model.solve()
+        
+        # raw_samples = self.qihd_backend.generate_samples(backend_params)
+
+        info["backend_time"] = time.time() - start_run_time
+        # info["average_qpu_time"] = self.dwp.avg_qpu_time
+        # info["time_on_machine"] = self.dwp.time_on_machine
+        # info["overhead_time"] = info["backend_time"] - info["time_on_machine"]
+
+        if verbose > 1:
+            print("Received results from PhiSolve:")
+            print(time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime()))
+
+        # if verbose > 0:
+        #     print(f"Backend QPU Time: {info['time_on_machine']}")
+        #     print(f"Overhead Time: {info['overhead_time']}\n")
+
+        # raw_samples = [spin_to_bitstring(result) for result in self.dwp.results()]
+
+        return self.phisolve_response.samples
+
+    def calc_h_and_J(self) -> Tuple[List, dict]:
+        """
+        Function for debugging to provide h and J which uniquely specify the problem hamiltonian
+
+        Returns:
+            h: List of h values
+            J: Dictionary of J values
+        """
+        (
+            penalty_coefficient,
+            chain_strength,
+        ) = self.calc_penalty_coefficient_and_chain_strength()
+        self.qs.add_evolution(
+            self.S_x(self.qubits) + self.H_p(self.qubits, self.univariate_dict, self.bivariate_dict) + penalty_coefficient * self.H_pen(self.qubits), 1
+        )
+
+        dwp = DWaveProvider(api_key='')
+        return dwp.compile(self.qs, chain_strength=.0)
+
+    def print_compilation_info(self):
+        print("* Compilation information")
+        print("Final Hamiltonian:")
+        print("(Feature under development; only the Hamiltonian is meaningful here)")
+        print(self.qs)
+        # print(f"Annealing schedule parameter: {self.anneal_schedule}")
+        print(f"Penalty coefficient: {self.penalty_coefficient}")
+        # print(f"Chain strength: {self.chain_strength}")
+        print(f"Number of shots: {self.shots}")

--- a/qhdopt/qhd.py
+++ b/qhdopt/qhd.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Union, Optional, Callable
 import jax.numpy as jnp
 import numpy as np
 import sympy
-from jax import grad, jacfwd, jacrev, jit
+from jax import grad, jacfwd, jacrev, jit, config
 from scipy.optimize import Bounds, minimize
 from sympy import lambdify
 from sympy.core.function import Function
@@ -16,6 +16,8 @@ from qhdopt.response import Response
 from qhdopt.utils.function_preprocessing_utils import gen_new_func_with_affine_trans, \
     generate_bounds, quad_to_gen
 
+# Enable float64 in Jax
+config.update("jax_enable_x64", True)
 
 class QHD:
     """
@@ -220,6 +222,31 @@ class QHD:
         self.post_processing_method = post_processing_method
         self.max_post_processing_num = max_post_processing_num
 
+    def phisolve_setup(
+            self,
+            resolution: int,
+            shots: int = 100,
+            embedding_scheme: str = "unary",
+            penalty_coefficient: float = 0,
+            penalty_ratio: float = 0.75,
+            post_processing_method: str = "TNC",
+            max_post_processing_num: int = None,
+    ):
+        """
+        """
+        func, syms = self.generate_affined_func()
+        self.qhd_base = QHD_Base(func, syms, self.info)
+        self.qhd_base.phisolve_setup(
+            resolution=resolution,
+            shots=shots,
+            embedding_scheme=embedding_scheme,
+            penalty_coefficient=penalty_coefficient,
+            penalty_ratio=penalty_ratio
+        )
+        self.shots = shots
+        self.post_processing_method = post_processing_method
+        self.max_post_processing_num = max_post_processing_num
+
     def affine_transformation(self, x: np.ndarray) -> np.ndarray:
         """
         Applies an affine transformation to the input array.
@@ -344,7 +371,7 @@ class QHD:
                 opt_samples.append(None)
                 continue
             sample_start_time = time.time()
-            x0 = jnp.array(samples[k])
+            x0 = jnp.array(samples[k], dtype=jnp.float64)
             if solver == "TNC":
                 result = minimize(
                     f_eval_jit,

--- a/qhdopt/qhd_base.py
+++ b/qhdopt/qhd_base.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Union, Optional
 from sympy import lambdify, Symbol, Function
 import jax.numpy as jnp
 
-from qhdopt.backend import dwave_backend, ionq_backend, qutip_backend
+from qhdopt.backend import dwave_backend, ionq_backend, qutip_backend, phisolve_backend
 from qhdopt.response import Response
 from qhdopt.utils.function_preprocessing_utils import decompose_function
 
@@ -150,6 +150,27 @@ class QHD_Base:
             penalty_coefficient=penalty_coefficient,
             time_discretization=time_discretization,
             gamma=gamma,
+        )
+
+    def phisolve_setup(
+        self,
+        resolution: int,
+        shots: int = 100,
+        embedding_scheme: str = "unary",
+        penalty_coefficient: float = 0,
+        penalty_ratio: float = 0.75
+    ) -> None:
+        """
+        """
+        self.backend = phisolve_backend.PhiSolveBackend(
+            resolution=resolution,
+            dimension=self.dimension,
+            univariate_dict=self.univariate_dict,
+            bivariate_dict=self.bivariate_dict,
+            shots=shots,
+            embedding_scheme=embedding_scheme,
+            penalty_coefficient=penalty_coefficient,
+            penalty_ratio=penalty_ratio,
         )
 
     def compile_only(self):


### PR DESCRIPTION
Major changes:
1. Enable Jax float64 (Jax by default deals with float32 after 0.6.0).
2. Add PhiSolve as a backend in QHDOPT. 
3. Add a notebook to test the `phisolve` backend. Test is implemented using [OpenPhiSolve](https://github.com/Artephi-Computing/OpenPhiSolve).
